### PR TITLE
DCAC-94: Use S3 URIs for document locations

### DIFF
--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/aws/S3Service.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/aws/S3Service.java
@@ -78,7 +78,9 @@ public class S3Service {
             throw new URISyntaxException(documentLocation,
                                          "No bucket name could be extracted from the document location");
         }
-        return host.substring(0, host.indexOf('.'));
+        // IFF there is no '.' in the host name, then we assume it's an S3 URI bucket name, otherwise an object URL
+        // host name starting with '<bucket name>.s3.eu-west-2.amazonaws.com' for example.
+        return host.indexOf('.') == -1 ? host : host.substring(0, host.indexOf('.'));
     }
 
     String getFileName(final String documentLocation) throws URISyntaxException {

--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/aws/S3Service.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/aws/S3Service.java
@@ -31,7 +31,7 @@ public class S3Service {
     /**
      * Retrieves the document from the location specified in S3.
      * @param documentLocation the document location, assumed to be the location of an (unsigned) document stored in S3,
-     *                         specified as an object URL string, or as an S3 URI string
+     *                         specified as an S3 URI string
      * @return {@link ResponseInputStream} of {@link GetObjectResponse} containing a reference to the document
      * @throws URISyntaxException should there be an issue parsing the S3 bucket name or S3 key name (a.k.a file path)
      * from the document location provided
@@ -68,14 +68,11 @@ public class S3Service {
     }
 
     String getBucketName(final String documentLocation) throws URISyntaxException {
-        final String host = new URI(documentLocation).getHost();
-        if (host == null) {
-            throw new URISyntaxException(documentLocation,
-                                         "No bucket name could be extracted from the document location");
+        final var uri = new URI(documentLocation);
+        if (uri.getScheme() == null || !uri.getScheme().equals("s3")) {
+            throw new URISyntaxException(documentLocation, "The document location provided is not a valid S3 URI");
         }
-        // IFF there is no '.' in the host name, then we assume it's an S3 URI bucket name, otherwise an object URL
-        // host name starting with '<bucket name>.s3.eu-west-2.amazonaws.com' for example.
-        return host.indexOf('.') == -1 ? host : host.substring(0, host.indexOf('.'));
+        return uri.getHost();
     }
 
     String getFileName(final String documentLocation) throws URISyntaxException {

--- a/src/test/java/uk/gov/companieshouse/documentsigningapi/aws/S3ServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningapi/aws/S3ServiceTest.java
@@ -9,14 +9,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3Utilities;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.net.URISyntaxException;
-import java.net.URL;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -44,12 +41,6 @@ class S3ServiceTest {
 
     @Mock
     private ResponseInputStream<GetObjectResponse> response;
-
-    @Mock
-    private S3Utilities s3Utilities;
-
-    @Mock
-    private URL signedDocumentLocationUrl;
 
     @Test
     @DisplayName("retrieveUnsignedDocument delegates retrieval to GetObject")
@@ -85,8 +76,6 @@ class S3ServiceTest {
     @DisplayName("storeSignedDocument stores signed document in named bucket")
     void storesSignedDocumentInNamedBucket() {
         final S3Service serviceUnderTest = new S3Service(s3Client, "bucket");
-        when(s3Client.utilities()).thenReturn(s3Utilities);
-        when(s3Utilities.getUrl(any(GetUrlRequest.class))).thenReturn(signedDocumentLocationUrl);
 
         serviceUnderTest.storeSignedDocument(new byte[]{}, "prefix/folder", "file");
 

--- a/src/test/java/uk/gov/companieshouse/documentsigningapi/controller/SignDocumentControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningapi/controller/SignDocumentControllerIntegrationTest.java
@@ -149,7 +149,7 @@ class SignDocumentControllerIntegrationTest {
 
         // It seems that LocalStack S3 is somewhat region-agnostic.
         final var unsignedDocumentLocation =
-                "https://" + UNSIGNED_BUCKET_NAME + ".s3.eu-west-2.amazonaws.com/" + UNSIGNED_DOCUMENT_NAME;
+                "s3://" + UNSIGNED_BUCKET_NAME + "/" + UNSIGNED_DOCUMENT_NAME;
         final var signPdfRequestDTO = createSignPdfRequest(unsignedDocumentLocation);
 
         final var pdf = s3Service.retrieveUnsignedDocument(unsignedDocumentLocation);
@@ -184,7 +184,7 @@ class SignDocumentControllerIntegrationTest {
 
         // It seems that LocalStack S3 is somewhat region-agnostic.
         final var unsignedDocumentLocation =
-                "https:// " + UNSIGNED_BUCKET_NAME + ".s3.eu-west-2.amazonaws.com/" + UNSIGNED_DOCUMENT_NAME;
+                "s3:// " + UNSIGNED_BUCKET_NAME + "/" + UNSIGNED_DOCUMENT_NAME;
         final var signPdfRequestDTO = createSignPdfRequest(unsignedDocumentLocation);
 
         final var resultActions = mockMvc.perform(post("/document-signing/sign-pdf")
@@ -193,8 +193,8 @@ class SignDocumentControllerIntegrationTest {
                 .andExpect(status().isBadRequest());
 
         final var body = resultActions.andReturn().getResponse().getContentAsString();
-        assertThat(body, is("Illegal character in authority at index 8: " +
-                "https:// document-api-images-cidev.s3.eu-west-2.amazonaws.com/9616659670.pdf"));
+        assertThat(body, is("Illegal character in authority at index 5: " +
+                "s3:// document-api-images-cidev/9616659670.pdf"));
     }
 
     @Test
@@ -203,7 +203,7 @@ class SignDocumentControllerIntegrationTest {
 
         // It seems that LocalStack S3 is somewhat region-agnostic.
         final var unsignedDocumentLocation =
-                "https://" + UNSIGNED_BUCKET_NAME + ".s3.eu-west-2.amazonaws.com/" + UNKNOWN_UNSIGNED_DOCUMENT_NAME;
+                "s3://" + UNSIGNED_BUCKET_NAME + "/" + UNKNOWN_UNSIGNED_DOCUMENT_NAME;
         final var signPdfRequestDTO = createSignPdfRequest(unsignedDocumentLocation);
 
         final var resultActions = mockMvc.perform(post("/document-signing/sign-pdf")

--- a/src/test/postman/Document_Signing_API.postman_collection.json
+++ b/src/test/postman/Document_Signing_API.postman_collection.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "_postman_id": "1e32e755-bddb-4f56-a0a9-f3897164c9e3",
+    "_postman_id": "d24f923a-3b88-4f22-a406-ad3f04faa8c2",
     "name": "Document Signing API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "_exporter_id": "7646296"
@@ -10,13 +10,41 @@
       "name": "sign PDF",
       "item": [
         {
-          "name": "sign PDF fairweather",
+          "name": "sign PDF fairweather object URL",
           "request": {
             "method": "POST",
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"document_location\": \"https://document-api-images-cidev.s3.eu-west-2.amazonaws.com/9616659670.pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"folder_name\": \"certified-copy\",\n    \"filename\": \"CCD-123456-123456.pdf\"\n}",
+              "raw": "{\n    \"document_location\": \"https://document-api-images-cidev.s3.eu-west-2.amazonaws.com/9616659670.pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"folder_name\": \"cidev/certified-copy\",\n    \"filename\": \"CCD-123456-123456.pdf\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{base_url}}/document-signing-api/document-signing/sign-pdf",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "document-signing-api",
+                "document-signing",
+                "sign-pdf"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "sign PDF fairweather S3 URI",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/9616659670.pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"folder_name\": \"cidev/certified-copy\",\n    \"filename\": \"CCD-123456-123456.pdf\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -44,7 +72,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"document_location\": \"https://document-api-images-cidev.s3.eu-west-2.amazonaws.com/9616659670.pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"filename\": \"CCD-123456-123456.pdf\"\n}",
+              "raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/9616659670.pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"filename\": \"CCD-123456-123456.pdf\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -72,7 +100,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"document_location\": \"https://document-api-images-cidev.s3.eu-west-2.amazonaws.com/9616659670.pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"folder_name\": \"cidev/certified-copy\"\n}",
+              "raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/9616659670.pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"folder_name\": \"cidev/certified-copy\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -100,7 +128,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"document_location\": \"https://document-api-images-cidev.s3.eu-west-2.amazonaws.com/9616659670.pdf\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"folder-name\": \"cidev/certified-copy\",\n    \"filename\": \"CCD-123456-123456.pdf\"\n}",
+              "raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/9616659670.pdf\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"folder-name\": \"cidev/certified-copy\",\n    \"filename\": \"CCD-123456-123456.pdf\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -128,7 +156,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"document_location\": \"https ://document-api-images-cidev.s3.eu-west-2.amazonaws.com/9616659670.pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"folder_name\": \"cidev/certified-copy\",\n    \"filename\": \"CCD-123456-123456.pdf\"\n}",
+              "raw": "{\n    \"document_location\": \"s3 ://document-api-images-cidev/9616659670.pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"folder_name\": \"cidev/certified-copy\",\n    \"filename\": \"CCD-123456-123456.pdf\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -156,7 +184,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"document_location\": \"https://document-api-images-cidev.s3.eu-west-2.amazonaws.com/NOT_FOUND.pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"folder_name\": \"cidev/certified-copy\",\n    \"filename\": \"CCD-123456-123456.pdf\"\n}",
+              "raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/NOT_FOUND.pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"folder_name\": \"cidev/certified-copy\",\n    \"filename\": \"CCD-123456-123456.pdf\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -184,7 +212,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"document_location\": \"https://document-api-images-cidev.s3.eu-west-2.amazonaws.com/9616659670.pdf\",\n    \"document_type\": \"unknown\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"folder_name\": \"cidev/certified-copy\",\n    \"filename\": \"CCD-123456-123456.pdf\"\n}",
+              "raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/9616659670.pdf\",\n    \"document_type\": \"unknown\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"folder_name\": \"cidev/certified-copy\",\n    \"filename\": \"CCD-123456-123456.pdf\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -212,7 +240,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"document_location\": \"https://document-api-images-cidev.s3.eu-west-2.amazonaws.com/9616659670.pdf\",\n    \"document_type\": \"certificate\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"folder_name\": \"cidev/certified-copy\",\n    \"filename\": \"CCD-123456-123456.pdf\"\n}",
+              "raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/9616659670.pdf\",\n    \"document_type\": \"certificate\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"folder_name\": \"cidev/certified-copy\",\n    \"filename\": \"CCD-123456-123456.pdf\"\n}",
               "options": {
                 "raw": {
                   "language": "json"


### PR DESCRIPTION
* Changes made so that the `signPdf` endpoint both expects the unsigned document location field it receives to be an S3 URI, and returns the location of the signed document as an S3 URI too.
* Previously, it was working with object URL document locations in both cases.