### PR TITLE
DCAC-92: Add cover sheet before signing document

### DIFF
--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/signing/SigningService.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/signing/SigningService.java
@@ -7,8 +7,6 @@ import org.apache.pdfbox.pdmodel.interactive.digitalsignature.SignatureInterface
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ResourceUtils;
-import software.amazon.awssdk.core.ResponseInputStream;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import uk.gov.companieshouse.documentsigningapi.exception.DocumentSigningException;
 import uk.gov.companieshouse.documentsigningapi.exception.DocumentUnavailableException;
 import uk.gov.companieshouse.documentsigningapi.logging.LoggingUtils;
@@ -48,12 +46,10 @@ public class SigningService {
         this.logger = logger;
     }
 
-    public byte[] signPDF(ResponseInputStream<GetObjectResponse> unsignedDoc) throws DocumentSigningException, DocumentUnavailableException {
+    public byte[] signPDF(byte[] pdfToSign) throws DocumentSigningException, DocumentUnavailableException {
         try {
             KeyStore keyStore = getKeyStore();
             Signature signature = new Signature(keyStore, this.keystorePassword.toCharArray(), certificateAlias);
-
-            final byte[] pdfToSign = unsignedDoc.readAllBytes();
 
             // Create new PDF file
             File pdfFile = File.createTempFile("pdf", "");

--- a/src/test/java/uk/gov/companieshouse/documentsigningapi/controller/SignDocumentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningapi/controller/SignDocumentControllerTest.java
@@ -121,8 +121,10 @@ class SignDocumentControllerTest {
     @DisplayName("signPdf adds cover sheet if required")
     void addsCoverSheetIfRequired() throws Exception {
         when(s3Service.retrieveUnsignedDocument(anyString())).thenReturn(unsignedDocument);
+        when(coverSheetService.addCoverSheet(any(byte[].class))).thenReturn(new byte[]{});
+        when(unsignedDocument.readAllBytes()).thenReturn(new byte[]{});
         when(loggingUtils.getLogger()).thenReturn(logger);
-        when(signingService.signPDF(unsignedDocument)).thenReturn(new byte[]{});
+
 
         final SignPdfRequestDTO signPdfRequestDTO = new SignPdfRequestDTO();
         signPdfRequestDTO.setDocumentLocation(TOKEN_UNSIGNED_DOCUMENT_LOCATION);
@@ -140,7 +142,6 @@ class SignDocumentControllerTest {
     void doesNotAddCoverSheetIfNotRequired() throws Exception {
         when(s3Service.retrieveUnsignedDocument(anyString())).thenReturn(unsignedDocument);
         when(loggingUtils.getLogger()).thenReturn(logger);
-        when(signingService.signPDF(unsignedDocument)).thenReturn(new byte[]{});
 
         final SignPdfRequestDTO signPdfRequestDTO = new SignPdfRequestDTO();
         signPdfRequestDTO.setDocumentLocation(TOKEN_UNSIGNED_DOCUMENT_LOCATION);

--- a/src/test/java/uk/gov/companieshouse/documentsigningapi/signing/SigningServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningapi/signing/SigningServiceTest.java
@@ -1,20 +1,18 @@
 package uk.gov.companieshouse.documentsigningapi.signing;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.core.ResponseInputStream;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import uk.gov.companieshouse.documentsigningapi.exception.DocumentSigningException;
 import uk.gov.companieshouse.documentsigningapi.exception.DocumentUnavailableException;
 import uk.gov.companieshouse.documentsigningapi.logging.LoggingUtils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 public class SigningServiceTest {
@@ -22,27 +20,24 @@ public class SigningServiceTest {
     @Mock
     private LoggingUtils logger;
 
-    @Mock
-    private ResponseInputStream<GetObjectResponse> response;
-
     @InjectMocks
     private SigningService signingService = new SigningService("jks", "src/test/resources/keystore.jks", "testkey", "alias", logger);
 
     @Test
     @DisplayName("Throws DocumentUnavailableException when unable to load keystore")
-    void throwsDocumentUnavailableExceptionExceptionWhereHostIsNull() {
+    void throwsDocumentUnavailableExceptionExceptionWhenUnableToLoadKeystore() {
         final DocumentUnavailableException exception = assertThrows(DocumentUnavailableException.class,
-            () -> signingService.signPDF(response));
+            () -> signingService.signPDF(new byte[]{}));
         assertThat(exception.getMessage(),
             is("Unable to load Keystore or Certificate"));
     }
 
     @Test
     @DisplayName("Throws DocumentSigningException when failing to obtain keystore")
-    void throwsDocumentSigningExceptionExceptionWhereHostIsNull() {
+    void throwsDocumentSigningExceptionExceptionWhenFailingToObtainKeystore() {
         SigningService incorrectKeystoreTypeInitialised = new SigningService("unknown", "src/test/resources/keystore.jks", "testkey", "alias", logger);
         final DocumentSigningException exception = assertThrows(DocumentSigningException.class,
-            () -> incorrectKeystoreTypeInitialised.signPDF(response));
+            () -> incorrectKeystoreTypeInitialised.signPDF(new byte[]{}));
         assertThat(exception.getMessage(),
             is("Failed to obtain proper KeyStore or Certificate"));
     }


### PR DESCRIPTION
* Found whilst exploring DCAC-108 that adding a cover sheet after signing the document seems to corrupt the signature.
* Avoid this by making the signing the last processing step for the document?

### Signature corrupted when cover sheet added after signing
![add cover sheet after - signature corrupted](https://user-images.githubusercontent.com/54801196/223764436-409d4556-1275-4160-9091-bb921d258c47.png)

### Signature not corrupted when cover sheet added before signing
![add cover sheet before - signature OK](https://user-images.githubusercontent.com/54801196/223764774-c227ffa8-c40a-4c92-9109-0ea7b966673c.png)

