### PR TITLE
DCAC-198: Add ch- prefixed resource to each image bucket policy statement

### DIFF
--- a/terraform/groups/document-signing-api/data.tf
+++ b/terraform/groups/document-signing-api/data.tf
@@ -9,7 +9,8 @@ data "aws_iam_policy_document" "image_bucket" {
     ]
 
     resources = [
-      "arn:aws:s3:::${var.image_bucket_name_prefix}-*"
+      "arn:aws:s3:::${var.image_bucket_name_prefix}-*",
+      "arn:aws:s3:::ch-${var.image_bucket_name_prefix}-*"
     ]
   }
 
@@ -23,7 +24,8 @@ data "aws_iam_policy_document" "image_bucket" {
     ]
 
     resources = [
-      "arn:aws:s3:::${var.image_bucket_name_prefix}-*/*"
+      "arn:aws:s3:::${var.image_bucket_name_prefix}-*/*",
+      "arn:aws:s3:::ch-${var.image_bucket_name_prefix}-*/*"
     ]
   }
 }

--- a/terraform/groups/document-signing-api/data.tf
+++ b/terraform/groups/document-signing-api/data.tf
@@ -9,8 +9,7 @@ data "aws_iam_policy_document" "image_bucket" {
     ]
 
     resources = [
-      "arn:aws:s3:::${var.image_bucket_name_prefix}-*",
-      "arn:aws:s3:::ch-${var.image_bucket_name_prefix}-*"
+      "arn:aws:s3:::${var.image_bucket_name_prefix}-*"
     ]
   }
 
@@ -24,8 +23,7 @@ data "aws_iam_policy_document" "image_bucket" {
     ]
 
     resources = [
-      "arn:aws:s3:::${var.image_bucket_name_prefix}-*/*",
-      "arn:aws:s3:::ch-${var.image_bucket_name_prefix}-*/*"
+      "arn:aws:s3:::${var.image_bucket_name_prefix}-*/*"
     ]
   }
 }

--- a/terraform/groups/document-signing-api/profiles/staging-eu-west-2/vars
+++ b/terraform/groups/document-signing-api/profiles/staging-eu-west-2/vars
@@ -1,1 +1,2 @@
 aws_account = "staging"
+image_bucket_name_prefix = "ch-document-api-images"


### PR DESCRIPTION
* Further testing today confirmed our impression that one of the current issues with the `staging` deployment of the `document-signing-api` is that whilst is has read access to the Document API(?) documents held on `s3://document-api-images-cidev`, it does not have read access to the Document API(?) documents held on `s3://ch-document-api-images-staging`.
* I speculate the appropriate read permissions may be extended to the staging image bucket as well by adding extra resources that hopefully match against the staging image bucket name with its `ch-` prefix.