### PR TITLE
Deprecate bucket ACL and replace with Object Ownership config

### DIFF
--- a/terraform/groups/document-signing-api/s3.tf
+++ b/terraform/groups/document-signing-api/s3.tf
@@ -2,11 +2,6 @@ resource "aws_s3_bucket" "signed" {
   bucket = "${var.service}.${var.aws_account}.ch.gov.uk"
 }
 
-resource "aws_s3_bucket_acl" "signed" {
-  bucket = aws_s3_bucket.signed.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_public_access_block" "signed" {
   bucket = aws_s3_bucket.signed.id
 
@@ -14,4 +9,12 @@ resource "aws_s3_bucket_public_access_block" "signed" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "data" {
+  bucket = aws_s3_bucket.signed.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
 }


### PR DESCRIPTION
S3 bucket ACLs are deprecated and the preferred method of access management is now Object Ownership configuration and IAM policies. This change removes the ACL configuration and replaces it with suitable Object Ownership configuration.