### PR TITLE
DCAC-271 - Generate Filing History Description for Coversheet

### DIFF
--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/controller/SignDocumentController.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/controller/SignDocumentController.java
@@ -103,7 +103,7 @@ public class SignDocumentController {
                                            final Calendar signingDate) {
         return request.getSignatureOptions() != null &&
                 request.getSignatureOptions().contains(COVER_SHEET_SIGNATURE_OPTION) ?
-                coverSheetService.addCoverSheet(document, request.getCoverSheetData(), signingDate) : document;
+                coverSheetService.addCoverSheet(document, request.getCoverSheetData(), request, signingDate) : document;
     }
 
     private ResponseEntity<Object> buildResponse(final String signedDocumentLocation,

--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/CoverSheetService.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/CoverSheetService.java
@@ -207,10 +207,9 @@ public class CoverSheetService {
     }
 
     private String extractFilingHistoryDescriptionHead(final CoverSheetDataDTO coverSheetDataDTO) {
-        String fullDescription = "Test";
+        String fullDescription = "";
         if (coverSheetDataDTO != null) {
             fullDescription = coverSheetDataDTO.getFilingHistoryDescription();
-
 
             if (fullDescription != null) {
 
@@ -221,7 +220,6 @@ public class CoverSheetService {
                     return matcher.group(1);
                 }
             }
-
         }
         return fullDescription;
     }

--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/CoverSheetService.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/CoverSheetService.java
@@ -206,6 +206,12 @@ public class CoverSheetService {
         return data.getCompanyName() + " (" + data.getCompanyNumber()+ ")";
     }
 
+    /**
+     * Extracts the first part of the filing history description from the CoverSheetDataDTO.
+     * Searches for text enclosed in double asterisks within the full description and returns extracted content.
+     * @param coverSheetDataDTO Coversheet Data containing filing history description
+     * @return The extracted data, or simply the full filing history description provided if it is not in the expected double asterisks format
+     */
     private String extractFilingHistoryDescriptionHead(final CoverSheetDataDTO coverSheetDataDTO) {
         String fullDescription = "";
         if (coverSheetDataDTO != null) {
@@ -224,6 +230,13 @@ public class CoverSheetService {
         return fullDescription;
     }
 
+    /**
+     * Extracts the first part of the filing history description from the CoverSheetDataDTO.
+     * Searches for text enclosed in double asterisks within the full description, identifying the head part, and returns
+     * the remaining content as the description tail.
+     * @param coverSheetDataDTO Coversheet Data containing filing history description
+     * @return The extracted data, or an empty string if there is no tail
+     */
     private String extractFilingHistoryDescriptionTail(final CoverSheetDataDTO coverSheetDataDTO) {
         if (coverSheetDataDTO != null) {
             String fullDescription = coverSheetDataDTO.getFilingHistoryDescription();
@@ -242,6 +255,13 @@ public class CoverSheetService {
         return "";
     }
 
+    /**
+     * Builds the complete filing history tail by replacing placeholder values with the correct values from the SignPdfDataDTO
+     * and appending the filing history type to the tail.
+     * @param signPdfData Contains filing history description values for placeholder spots
+     * @param coverSheetData contains additional filing history type value
+     * @return the populated tail of the filing history description
+     */
     private String buildFilingHistoryDescriptionTailWithValues(final SignPdfRequestDTO signPdfData, final  CoverSheetDataDTO coverSheetData) {
         String filingHistoryDescriptionTail = extractFilingHistoryDescriptionTail(coverSheetData);
 
@@ -255,6 +275,13 @@ public class CoverSheetService {
         return filingHistoryDescriptionTail;
     }
 
+    /**
+     * Replaces placeholders in the filing history description tail with values from the provided map.
+     * Each placeholder in the tail is identified and replaced with its corresponding value.
+     * @param input The original tail string containing placeholders to be replaced
+     * @param placeholderValues A map of placeholders and their corresponding values
+     * @return modified string with placeholder values correctly filled
+     */
     private String replaceFilingHistoryDescriptionPlaceholders(String input, Map<String, String> placeholderValues) {
         for (Map.Entry<String, String> entry : placeholderValues.entrySet()) {
             String placeholder = "{" + entry.getKey() + "}";
@@ -264,6 +291,17 @@ public class CoverSheetService {
         return input;
     }
 
+    /**
+     * Renders a full filing history description on the pDF, combining the extracted head and populated tail, wrapping the text if necessary.
+     * @param filingHistoryDescriptionHead The first part of the filing history description
+     * @param filingHistoryDescriptionTail The second part of the filing history description
+     * @param font1 font1 for rendering
+     * @param font2 font2 for rendering
+     * @param page The PDF page
+     * @param contentStream The content stream for rendering
+     * @param position The starting position on the page
+     * @throws IOException If an I/O error occurs during rendering
+     */
     private void renderFilingHistoryDescriptionWithBoldText(final String filingHistoryDescriptionHead,
                                                             final String filingHistoryDescriptionTail,
                                                             final Font font1,
@@ -273,8 +311,10 @@ public class CoverSheetService {
                                                             final Position position)
                                                             throws IOException {
 
+        // Combine head and tail into single text
         String combinedText = filingHistoryDescriptionHead + filingHistoryDescriptionTail;
 
+        // Wrap combined text
         String[] wrappedText = WordUtils.wrap(combinedText, 60). split("\\r?\\n");
 
         contentStream.beginText();

--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/CoverSheetService.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/CoverSheetService.java
@@ -266,45 +266,6 @@ public class CoverSheetService {
         return input;
     }
 
-//    private void renderFilingHistoryDescriptionWithBoldText(final String filingHistoryDescriptionHead,
-//                                                            final String filingHistoryDescriptionTail,
-//                                                            final Font font1,
-//                                                            final Font font2,
-//                                                            final PDPage page,
-//                                                            final PDPageContentStream contentStream,
-//                                                            final Position position)
-//            throws IOException {
-//
-//        String combinedText = filingHistoryDescriptionHead + filingHistoryDescriptionTail;
-//
-//        String[] wrappedText = WordUtils.wrap(combinedText, 60). split("\\r?\\n");
-//
-//        contentStream.beginText();
-//        contentStream.newLineAtOffset(position.x, position.y);
-//
-//        for (int i=0; i < wrappedText.length; i++) {
-//            String line = wrappedText[i];
-//
-//            int headIndex = line.indexOf(filingHistoryDescriptionHead);
-//            boolean lineContainsHead = headIndex >= 0;
-//
-//            contentStream.setFont(font2.getPdFont(), font2.getSize());
-//            contentStream.showText(lineContainsHead ? line.substring(0, headIndex) : line);
-//
-//            contentStream.setFont(font1.getPdFont(), font1.getSize());
-//            if (lineContainsHead && line.length() > headIndex) {
-//                contentStream.showText(line.substring(headIndex));
-//            }
-//
-//            if (i < wrappedText.length - 1) {
-//                contentStream.newLineAtOffset(0, -Math.max(font2.getSize(), font2.getSize()));
-//            }
-//        }
-//
-//        contentStream.endText();
-//    };
-
-
     private void renderFilingHistoryDescriptionWithBoldText(final String filingHistoryDescriptionHead,
                                                             final String filingHistoryDescriptionTail,
                                                             final Font font1,
@@ -314,10 +275,7 @@ public class CoverSheetService {
                                                             final Position position)
                                                             throws IOException {
 
-
         String combinedText = filingHistoryDescriptionHead + filingHistoryDescriptionTail;
-
-
 
         String[] wrappedText = WordUtils.wrap(combinedText, 60). split("\\r?\\n");
 
@@ -330,8 +288,6 @@ public class CoverSheetService {
             if(filingHistoryDescriptionHead != null){
 
             int headIndex = line.indexOf(filingHistoryDescriptionHead);
-
-
 
             if (headIndex >= 0) {
                 contentStream.setFont(font1.getPdFont(), font1.getSize());
@@ -349,8 +305,8 @@ public class CoverSheetService {
                     contentStream.newLineAtOffset(0, -font2.getSize());
                 }
 
+                }
             }
-        }
         }
         contentStream.endText();
     };

--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/dto/SignPdfRequestDTO.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/dto/SignPdfRequestDTO.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.documentsigningapi.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Map;
 
 public class SignPdfRequestDTO {
 
@@ -24,13 +25,17 @@ public class SignPdfRequestDTO {
     @JsonProperty("cover_sheet_data")
     private CoverSheetDataDTO coverSheetData;
 
-    public SignPdfRequestDTO(String documentLocation, String documentType, List<String> signatureOptions, String prefix, String key, CoverSheetDataDTO coverSheetData) {
+    @JsonProperty("filing_history_description_values")
+    private Map<String, String> filingHistoryDescriptionValues;
+
+    public SignPdfRequestDTO(String documentLocation, String documentType, List<String> signatureOptions, String prefix, String key, CoverSheetDataDTO coverSheetData, Map<String, String> filingHistoryDescriptionValues) {
         this.documentLocation = documentLocation;
         this.documentType = documentType;
         this.signatureOptions = signatureOptions;
         this.prefix = prefix;
         this.key = key;
         this.coverSheetData = coverSheetData;
+        this.filingHistoryDescriptionValues = filingHistoryDescriptionValues;
     }
 
     public SignPdfRequestDTO() {
@@ -84,6 +89,10 @@ public class SignPdfRequestDTO {
         this.coverSheetData = coverSheetData;
     }
 
+    public Map<String, String> getFilingHistoryDescriptionValues() { return filingHistoryDescriptionValues; }
+
+    public void setFilingHistoryDescriptionValues(Map<String, String> filingHistoryDescriptionValues) { this.filingHistoryDescriptionValues = filingHistoryDescriptionValues; }
+
     @Override
     public String toString() {
         return "SignPdfRequestDTO{" +
@@ -93,6 +102,7 @@ public class SignPdfRequestDTO {
                 ", prefix='" + prefix + '\'' +
                 ", key='" + key + '\'' +
                 ", coverSheetData=" + coverSheetData +
+                ", filingHistoryDescriptionValues=" + filingHistoryDescriptionValues +
                 '}';
     }
 }

--- a/src/test/java/uk/gov/companieshouse/documentsigningapi/controller/SignDocumentControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningapi/controller/SignDocumentControllerIntegrationTest.java
@@ -351,7 +351,7 @@ class SignDocumentControllerIntegrationTest {
             IOException {
         verify(requestValidator).validateRequest(any(SignPdfRequestDTO.class));
         verify(s3Service).retrieveUnsignedDocument(any(String.class));
-        verify(coverSheetService).addCoverSheet(any(byte[].class), any(CoverSheetDataDTO.class), any(Calendar.class));
+        verify(coverSheetService).addCoverSheet(any(byte[].class), any(CoverSheetDataDTO.class), any(SignPdfRequestDTO.class), any(Calendar.class));
         verify(visualSignature).renderPanel(
                 any(PDPageContentStream.class), any(PDDocument.class), any(PDPage.class), any(Calendar.class));
         verify(signingService).signPDF(any(byte[].class), any(Calendar.class));

--- a/src/test/java/uk/gov/companieshouse/documentsigningapi/controller/SignDocumentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningapi/controller/SignDocumentControllerTest.java
@@ -137,7 +137,7 @@ class SignDocumentControllerTest {
     @DisplayName("signPdf adds cover sheet if required")
     void addsCoverSheetIfRequired() throws Exception {
         when(s3Service.retrieveUnsignedDocument(anyString())).thenReturn(unsignedDocument);
-        when(coverSheetService.addCoverSheet(any(byte[].class), any(CoverSheetDataDTO.class), any(Calendar.class)))
+        when(coverSheetService.addCoverSheet(any(byte[].class), any(CoverSheetDataDTO.class), any(SignPdfRequestDTO.class), any(Calendar.class)))
                 .thenReturn(new byte[]{});
         when(unsignedDocument.readAllBytes()).thenReturn(new byte[]{});
         when(loggingUtils.getLogger()).thenReturn(logger);
@@ -151,7 +151,7 @@ class SignDocumentControllerTest {
 
         controller.signPdf(signPdfRequestDTO);
 
-        verify(coverSheetService).addCoverSheet(any(byte[].class), any(CoverSheetDataDTO.class), any(Calendar.class));
+        verify(coverSheetService).addCoverSheet(any(byte[].class), any(CoverSheetDataDTO.class), any(SignPdfRequestDTO.class), any(Calendar.class));
 
     }
 
@@ -169,7 +169,7 @@ class SignDocumentControllerTest {
         controller.signPdf(signPdfRequestDTO);
 
         verify(coverSheetService, times(0))
-                .addCoverSheet(any(byte[].class), any(CoverSheetDataDTO.class), any(Calendar.class));
+                .addCoverSheet(any(byte[].class), any(CoverSheetDataDTO.class), any(SignPdfRequestDTO.class), any(Calendar.class));
     }
     //
     // ERIC headers for auth-auth

--- a/src/test/java/uk/gov/companieshouse/documentsigningapi/coversheet/CoverSheetServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningapi/coversheet/CoverSheetServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.documentsigningapi.dto.CoverSheetDataDTO;
+import uk.gov.companieshouse.documentsigningapi.dto.SignPdfRequestDTO;
 import uk.gov.companieshouse.documentsigningapi.exception.CoverSheetException;
 import uk.gov.companieshouse.documentsigningapi.logging.LoggingUtils;
 import uk.gov.companieshouse.logging.Logger;
@@ -90,6 +91,9 @@ class CoverSheetServiceTest {
     private CoverSheetDataDTO coverSheetData;
 
     @Mock
+    private SignPdfRequestDTO signPdfRequestData;
+
+    @Mock
     private VisualSignature visualSignature;
 
     @Mock
@@ -112,7 +116,7 @@ class CoverSheetServiceTest {
         executeTest((pdfBox, pageConstructor, streamConstructor, linkConstructor) -> {
 
             final byte[] docWithCoverSheet =
-                    coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), Calendar.getInstance());
+                    coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), any(SignPdfRequestDTO.class), Calendar.getInstance());
 
             assertThat(pageConstructor.constructed().size(), is(1));
             verify(pages).insertBefore(pageConstructor.constructed().get(0), page);
@@ -129,7 +133,7 @@ class CoverSheetServiceTest {
 
             when(imagesBean.createImage(any(String.class), eq(document))).thenReturn(image);
 
-            coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), Calendar.getInstance());
+            coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), any(SignPdfRequestDTO.class), Calendar.getInstance());
 
             verify(imagesBean, times(3)).createImage(any(String.class), eq(document));
             assertThat(streamConstructor.constructed().size(), is (1));
@@ -144,15 +148,15 @@ class CoverSheetServiceTest {
     }
 
     @Test
-    @DisplayName("addCoverSheet renders text 17 times")
+    @DisplayName("addCoverSheet renders text 14 times")
     void rendersText() throws IOException {
         executeTest((pdfBox, pageConstructor, streamConstructor, linkConstructor) -> {
 
-            coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), Calendar.getInstance());
+            coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), new SignPdfRequestDTO(), Calendar.getInstance());
 
             assertThat(streamConstructor.constructed().size(), is (1));
             final var stream = streamConstructor.constructed().get(0);
-            verify(stream, times(15)).showText(any(String.class));
+            verify(stream, times(14)).showText(any(String.class));
         });
     }
 
@@ -161,7 +165,7 @@ class CoverSheetServiceTest {
     void createsLinkAndAddsItToCoverSheet() throws IOException {
         executeTest((pdfBox, pageConstructor, streamConstructor, linkConstructor) -> {
 
-            coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), Calendar.getInstance());
+            coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), any(SignPdfRequestDTO.class), Calendar.getInstance());
 
             assertThat(pageConstructor.constructed().size(), is(1));
             final var coverSheet = pageConstructor.constructed().get(0);
@@ -177,7 +181,7 @@ class CoverSheetServiceTest {
     void rendersLinkTextInBlue() throws IOException {
         executeTest((pdfBox, pageConstructor, streamConstructor, linkConstructor) -> {
 
-            coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), Calendar.getInstance());
+            coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), any(SignPdfRequestDTO.class), Calendar.getInstance());
 
             assertThat(streamConstructor.constructed().size(), is (1));
             final var stream = streamConstructor.constructed().get(0);
@@ -191,7 +195,7 @@ class CoverSheetServiceTest {
     void underlinesLink() throws IOException {
         executeTest((pdfBox, pageConstructor, streamConstructor, linkConstructor) -> {
 
-            coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), Calendar.getInstance());
+            coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), any(SignPdfRequestDTO.class), Calendar.getInstance());
 
             assertThat(linkConstructor.constructed().size(), is (1));
             final var link = linkConstructor.constructed().get(0);
@@ -205,7 +209,7 @@ class CoverSheetServiceTest {
     void marksUpClickableArea() throws IOException {
         executeTest((pdfBox, pageConstructor, streamConstructor, linkConstructor) -> {
 
-            coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), Calendar.getInstance());
+            coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), any(SignPdfRequestDTO.class), Calendar.getInstance());
 
             assertThat(linkConstructor.constructed().size(), is (1));
             final var link = linkConstructor.constructed().get(0);
@@ -219,7 +223,7 @@ class CoverSheetServiceTest {
     void setsUpLinkAction() throws IOException {
         executeTest((pdfBox, pageConstructor, streamConstructor, linkConstructor) -> {
 
-            coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), Calendar.getInstance());
+            coverSheetService.addCoverSheet(new byte[]{}, new CoverSheetDataDTO(), any(SignPdfRequestDTO.class), Calendar.getInstance());
 
             assertThat(linkConstructor.constructed().size(), is (1));
             final var link = linkConstructor.constructed().get(0);
@@ -238,7 +242,7 @@ class CoverSheetServiceTest {
                 final CoverSheetException exception =
                         assertThrows(CoverSheetException.class,
                                 () -> coverSheetService.addCoverSheet(
-                                        new byte[]{}, coverSheetData, signingDate));
+                                        new byte[]{}, coverSheetData, signPdfRequestData, signingDate));
 
                 assertThat(pageConstructor.constructed().size(), is(0));
                 verify(logger).error(PDF_BOX_ORIGINATED_EXCEPTION.getMessage(), PDF_BOX_ORIGINATED_EXCEPTION);

--- a/src/test/java/uk/gov/companieshouse/documentsigningapi/validation/RequestValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningapi/validation/RequestValidatorTest.java
@@ -8,6 +8,7 @@ import uk.gov.companieshouse.documentsigningapi.dto.SignPdfRequestDTO;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 class RequestValidatorTest {
 
@@ -20,6 +21,10 @@ class RequestValidatorTest {
     private static final String COMPANY_NUMBER = "00000000";
     private static final String FILING_HISTORY_TYPE = "ad01";
     private static final String FILING_HISTORY_DESCRIPTION = "this is an ad01 description";
+
+    private static final Map<String, String> FILING_HISTORY_DESCRIPTION_VALUES = Map.of("date", "2023-01-01",
+            "director", "Test Director");
+
     private static final CoverSheetDataDTO COVER_SHEET_DATA= new CoverSheetDataDTO(COMPANY_NAME, COMPANY_NUMBER,
         FILING_HISTORY_DESCRIPTION, FILING_HISTORY_TYPE);
     private static final CoverSheetDataDTO COVER_SHEET_DATA_MISSING_FIELD= new CoverSheetDataDTO(COMPANY_NAME, COMPANY_NUMBER,
@@ -43,7 +48,7 @@ class RequestValidatorTest {
     @DisplayName("validate request returns no errors")
     void validateRequestReturnsNoErrors() {
         final SignPdfRequestDTO dto = new SignPdfRequestDTO(DOCUMENT_LOCATION, DOCUMENT_TYPE,
-            SIGNATURE_OPTIONS, PREFIX, KEY, COVER_SHEET_DATA);
+            SIGNATURE_OPTIONS, PREFIX, KEY, COVER_SHEET_DATA, FILING_HISTORY_DESCRIPTION_VALUES);
 
         RequestValidator requestValidator = new RequestValidator();
         List<String> errors = requestValidator.validateRequest(dto);
@@ -55,7 +60,7 @@ class RequestValidatorTest {
     @DisplayName("validate request returns no errors without optional fields")
     void validateRequestReturnsNoErrorsWithoutOptionals() {
         final SignPdfRequestDTO dto = new SignPdfRequestDTO(DOCUMENT_LOCATION, DOCUMENT_TYPE,
-            null, PREFIX, KEY, null);
+            null, PREFIX, KEY, null, FILING_HISTORY_DESCRIPTION_VALUES);
 
         RequestValidator requestValidator = new RequestValidator();
         List<String> errors = requestValidator.validateRequest(dto);
@@ -67,7 +72,7 @@ class RequestValidatorTest {
     @DisplayName("validate request returns prefix missing error")
     void validateRequestReturnsPrefixMissingError() {
         final SignPdfRequestDTO dto = new SignPdfRequestDTO(DOCUMENT_LOCATION, DOCUMENT_TYPE,
-            SIGNATURE_OPTIONS, null, KEY, COVER_SHEET_DATA);
+            SIGNATURE_OPTIONS, null, KEY, COVER_SHEET_DATA, FILING_HISTORY_DESCRIPTION_VALUES);
 
         RequestValidator requestValidator = new RequestValidator();
         List<String> errors = requestValidator.validateRequest(dto);
@@ -80,7 +85,7 @@ class RequestValidatorTest {
     @DisplayName("validate request returns key missing error")
     void validateRequestReturnsKeyMissingError() {
         final SignPdfRequestDTO dto = new SignPdfRequestDTO(DOCUMENT_LOCATION, DOCUMENT_TYPE,
-            SIGNATURE_OPTIONS, PREFIX, null, COVER_SHEET_DATA);
+            SIGNATURE_OPTIONS, PREFIX, null, COVER_SHEET_DATA, FILING_HISTORY_DESCRIPTION_VALUES);
 
         RequestValidator requestValidator = new RequestValidator();
         List<String> errors = requestValidator.validateRequest(dto);
@@ -93,7 +98,7 @@ class RequestValidatorTest {
     @DisplayName("validate request returns document type missing error")
     void validateRequestReturnsDocumentTypeMissingError() {
         final SignPdfRequestDTO dto = new SignPdfRequestDTO(DOCUMENT_LOCATION, null,
-            SIGNATURE_OPTIONS, PREFIX, KEY, COVER_SHEET_DATA);
+            SIGNATURE_OPTIONS, PREFIX, KEY, COVER_SHEET_DATA, FILING_HISTORY_DESCRIPTION_VALUES);
 
         RequestValidator requestValidator = new RequestValidator();
         List<String> errors = requestValidator.validateRequest(dto);
@@ -106,7 +111,7 @@ class RequestValidatorTest {
     @DisplayName("validate request returns document location missing error")
     void validateRequestReturnsDocumentLocationMissingError() {
         final SignPdfRequestDTO dto = new SignPdfRequestDTO(null, DOCUMENT_TYPE,
-            SIGNATURE_OPTIONS, PREFIX, KEY, COVER_SHEET_DATA);
+            SIGNATURE_OPTIONS, PREFIX, KEY, COVER_SHEET_DATA, FILING_HISTORY_DESCRIPTION_VALUES);
 
         RequestValidator requestValidator = new RequestValidator();
         List<String> errors = requestValidator.validateRequest(dto);
@@ -119,7 +124,7 @@ class RequestValidatorTest {
     @DisplayName("validate request returns cover sheet data missing error")
     void validateRequestReturnsCoverSheetDataMissingError() {
         final SignPdfRequestDTO dto = new SignPdfRequestDTO(DOCUMENT_LOCATION, DOCUMENT_TYPE,
-            SIGNATURE_OPTIONS, PREFIX, KEY, null);
+            SIGNATURE_OPTIONS, PREFIX, KEY, null, FILING_HISTORY_DESCRIPTION_VALUES);
 
         RequestValidator requestValidator = new RequestValidator();
         List<String> errors = requestValidator.validateRequest(dto);
@@ -132,7 +137,7 @@ class RequestValidatorTest {
     @DisplayName("validate request returns cover sheet filing_history_type and/or filing_history_description missing error")
     void validateRequestReturnsCoverSheetDataFieldsMissingError() {
         final SignPdfRequestDTO dto = new SignPdfRequestDTO(DOCUMENT_LOCATION, DOCUMENT_TYPE,
-            SIGNATURE_OPTIONS, PREFIX, KEY, COVER_SHEET_DATA_MISSING_FIELD);
+            SIGNATURE_OPTIONS, PREFIX, KEY, COVER_SHEET_DATA_MISSING_FIELD, FILING_HISTORY_DESCRIPTION_VALUES);
 
         RequestValidator requestValidator = new RequestValidator();
         List<String> errors = requestValidator.validateRequest(dto);
@@ -150,7 +155,8 @@ class RequestValidatorTest {
             SIGNATURE_OPTIONS,
             PREFIX,
             KEY,
-            COVER_SHEET_DATA_MISSING_COMPANY_NAME);
+            COVER_SHEET_DATA_MISSING_COMPANY_NAME,
+                FILING_HISTORY_DESCRIPTION_VALUES);
 
         RequestValidator requestValidator = new RequestValidator();
         List<String> errors = requestValidator.validateRequest(dto);
@@ -168,7 +174,8 @@ class RequestValidatorTest {
             SIGNATURE_OPTIONS,
             PREFIX,
             KEY,
-            COVER_SHEET_DATA_MISSING_COMPANY_NUMBER);
+            COVER_SHEET_DATA_MISSING_COMPANY_NUMBER,
+                FILING_HISTORY_DESCRIPTION_VALUES);
 
         RequestValidator requestValidator = new RequestValidator();
         List<String> errors = requestValidator.validateRequest(dto);

--- a/src/test/postman/Document Signing API.postman_collection.json
+++ b/src/test/postman/Document Signing API.postman_collection.json
@@ -1,0 +1,489 @@
+{
+	"info": {
+		"_postman_id": "335c57b2-a2c8-4123-a502-91e7fe73ca6f",
+		"name": "Document Signing API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "19094781"
+	},
+	"item": [
+		{
+			"name": "sign PDF",
+			"item": [
+				{
+					"name": "sign PDF fairweather",
+					"request": {
+						"auth": {
+							"type": "apikey",
+							"apikey": [
+								{
+									"key": "key",
+									"value": "Authorization",
+									"type": "string"
+								},
+								{
+									"key": "value",
+									"value": "g9yZIA81Zo9J46Kzp3JPbfld6kOqxR47EAYqXbRV",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "g9yZIA81Zo9J46Kzp3JPbfld6kOqxR47EAYqXbRV",
+								"type": "text",
+								"disabled": true
+							},
+							{
+								"key": "ERIC-Authorised-Key-Roles",
+								"value": "*",
+								"type": "text"
+							},
+							{
+								"key": "ERIC-Identity-Type",
+								"value": "*",
+								"type": "text"
+							},
+							{
+								"key": "ERIC-Identity",
+								"value": "*",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/docs/--EdB7fbldt5oujK6Nz7jZ3hGj_x6vW8Q_2gQTyjWBM/application-pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"prefix\": \"docker/certified-copy\",\n    \"key\": \"application-pdf\",\n    \"cover_sheet_data\": {\n        \"company_name\": \"LINK EXPORTS (UK) LTD\",\n        \"company_number\": \"12953358\",\n        \"filing_history_description\": \"**Registered office address changed** from {old_address} to {new_address} on {change_date}\",\n        \"filing_history_type\": \"AD01\"\n    },\n    \"filing_history_description_values\": {\n        \"old_address\" : \"10 Test Lane\",\n        \"new_address\" : \"25 Test Avenue\",\n        \"change_date\" : \"25-10-2023\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/document-signing/sign-pdf",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"document-signing",
+								"sign-pdf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "sign PDF missing company NAME",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/9616659670.pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"prefix\": \"cidev/certified-copy\",\n    \"key\": \"CCD-123456-123456.pdf\",\n    \"cover_sheet_data\": {\n//        \"company_name\": \"LINK EXPORTS (UK) LTD\",\n//        \"company_name\": \"\",\n        \"company_number\": \"12953358\",\n        \"filing_history_description\": \"Change of Registered Office Address\",\n        \"filing_history_type\": \"AD01\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/document-signing/sign-pdf",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"document-signing",
+								"sign-pdf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "sign PDF missing company NUMBER",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/9616659670.pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"prefix\": \"cidev/certified-copy\",\n    \"key\": \"CCD-123456-123456.pdf\",\n    \"cover_sheet_data\": {\n        \"company_name\": \"LINK EXPORTS (UK) LTD\",\n//        \"company_number\": \"\",\n        \"filing_history_description\": \"Change of Registered Office Address\",\n        \"filing_history_type\": \"AD01\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/document-signing/sign-pdf",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"document-signing",
+								"sign-pdf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "sign PDF object URL",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"document_location\": \"https://document-api-images-cidev.s3.eu-west-2.amazonaws.com/docs/--EdB7fbldt5oujK6Nz7jZ3hGj_x6vW8Q_2gQTyjWBM/application-pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"prefix\": \"cidev/certified-copy\",\n    \"key\": \"application-pdf\",\n    \"cover_sheet_data\": {\n        \"company_name\": \"LINK EXPORTS (UK) LTD\",\n        \"company_number\": \"12953358\",\n        \"filing_history_description\": \"Change of Registered Office Address\",\n        \"filing_history_type\": \"AD01\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/document-signing/sign-pdf",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"document-signing",
+								"sign-pdf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "sign PDF no signature options",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/docs/--EdB7fbldt5oujK6Nz7jZ3hGj_x6vW8Q_2gQTyjWBM/application-pdf\",\n    \"document_type\": \"certified-copy\",\n    \"prefix\": \"cidev/certified-copy\",\n    \"key\": \"application-pdf\",\n    \"cover_sheet_data\": {\n        \"company_name\": \"LINK EXPORTS (UK) LTD\",\n        \"company_number\": \"12953358\",\n        \"filing_history_description\": \"Change of Registered Office Address\",\n        \"filing_history_type\": \"AD01\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/document-signing/sign-pdf",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"document-signing",
+								"sign-pdf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "sign PDF missing folder name",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/docs/--EdB7fbldt5oujK6Nz7jZ3hGj_x6vW8Q_2gQTyjWBM/application-pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"key\": \"application-pdf\",\n    \"cover_sheet_data\": {\n        \"company_name\": \"LINK EXPORTS (UK) LTD\",\n        \"company_number\": \"12953358\",\n        \"filing_history_description\": \"Change of Registered Office Address\",\n        \"filing_history_type\": \"AD01\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/document-signing/sign-pdf",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"document-signing",
+								"sign-pdf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "sign PDF missing key",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/docs/--EdB7fbldt5oujK6Nz7jZ3hGj_x6vW8Q_2gQTyjWBM/application-pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"prefix\": \"cidev/certified-copy\",\n    \"cover_sheet_data\": {\n        \"company_name\": \"LINK EXPORTS (UK) LTD\",\n        \"company_number\": \"12953358\",\n        \"filing_history_description\": \"Change of Registered Office Address\",\n        \"filing_history_type\": \"AD01\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/document-signing/sign-pdf",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"document-signing",
+								"sign-pdf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "sign PDF missing document type",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/docs/--EdB7fbldt5oujK6Nz7jZ3hGj_x6vW8Q_2gQTyjWBM/application-pdf\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"prefix\": \"cidev/certified-copy\",\n    \"key\": \"application-pdf\",\n    \"cover_sheet_data\": {\n        \"company_name\": \"LINK EXPORTS (UK) LTD\",\n        \"company_number\": \"12953358\",\n        \"filing_history_description\": \"Change of Registered Office Address\",\n        \"filing_history_type\": \"AD01\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/document-signing/sign-pdf",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"document-signing",
+								"sign-pdf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "sign PDF invalid document location",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/docs/--EdB7fbldt5oujK6Nz7jZ3hGj_x6vW8Q_2gQTyjWBM/application-pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"prefix\": \"cidev/certified-copy\",\n    \"key\": \"application-pdf\",\n    \"cover_sheet_data\": {\n        \"company_name\": \"LINK EXPORTS (UK) LTD\",\n        \"company_number\": \"12953358\",\n        \"filing_history_description\": \"Change of Registered Office Address\",\n        \"filing_history_type\": \"AD01\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/document-signing/sign-pdf",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"document-signing",
+								"sign-pdf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "sign PDF unsigned document not found",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/NOT_FOUND.pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"prefix\": \"cidev/certified-copy\",\n    \"key\": \"CCD-123456-123456.pdf\",\n    \"cover_sheet_data\": {\n        \"company_name\": \"LINK EXPORTS (UK) LTD\",\n        \"company_number\": \"12953358\",\n        \"filing_history_description\": \"Change of Registered Office Address\",\n        \"filing_history_type\": \"AD01\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/document-signing/sign-pdf",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"document-signing",
+								"sign-pdf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "sign PDF invalid document type",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/docs/--EdB7fbldt5oujK6Nz7jZ3hGj_x6vW8Q_2gQTyjWBM/application-pdf\",\n    \"document_type\": \"unknown\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"prefix\": \"cidev/certified-copy\",\n    \"key\": \"application-pdf\",\n    \"cover_sheet_data\": {\n        \"company_name\": \"LINK EXPORTS (UK) LTD\",\n        \"company_number\": \"12953358\",\n        \"filing_history_description\": \"Change of Registered Office Address\",\n        \"filing_history_type\": \"AD01\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/document-signing/sign-pdf",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"document-signing",
+								"sign-pdf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "sign PDF certificate document type",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/docs/--EdB7fbldt5oujK6Nz7jZ3hGj_x6vW8Q_2gQTyjWBM/application-pdf\",\n    \"document_type\": \"certificate\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"prefix\": \"cidev/certified-copy\",\n    \"key\": \"application-pdf\",\n    \"cover_sheet_data\": {\n        \"company_name\": \"LINK EXPORTS (UK) LTD\",\n        \"company_number\": \"12953358\",\n        \"filing_history_description\": \"Change of Registered Office Address\",\n        \"filing_history_type\": \"AD01\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/document-signing/sign-pdf",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"document-signing",
+								"sign-pdf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "sign PDF no request body",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/document-signing/sign-pdf",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"document-signing",
+								"sign-pdf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "sign PDF no cover sheet data",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"document_location\": \"s3://document-api-images-cidev/docs/--EdB7fbldt5oujK6Nz7jZ3hGj_x6vW8Q_2gQTyjWBM/application-pdf\",\n    \"document_type\": \"certified-copy\",\n    \"signature_options\": [\n        \"cover-sheet\"\n    ],\n    \"prefix\": \"cidev/certified-copy\",\n    \"key\": \"application-pdf\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/document-signing/sign-pdf",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"document-signing",
+								"sign-pdf"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "health check",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "",
+						"value": "",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{base_url}}/document-signing-api/healthcheck",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"document-signing-api",
+						"healthcheck"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"auth": {
+		"type": "apikey",
+		"apikey": [
+			{
+				"key": "value",
+				"value": "{{api_key}}",
+				"type": "string"
+			},
+			{
+				"key": "key",
+				"value": "Authorization",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	]
+}


### PR DESCRIPTION
Fulfils [DCAC-271](https://companieshouse.atlassian.net/browse/DCAC-271)

Taking original format of filing history description as shown on ticket:

"Registered office address changed** from {old_address} to {new_address} on {change_date}"

When submitted now looks like:

<img width="990" alt="Screenshot 2023-11-23 at 15 54 52" src="https://github.com/companieshouse/document-signing-api/assets/95215074/e5907912-ffc1-4cd9-903b-983c06e8e151">

If submitted not in this format, will display readable message anyway, i.e if you submit:

"Registered office address changed"

Will display as:

<img width="966" alt="Screenshot 2023-11-23 at 15 57 31" src="https://github.com/companieshouse/document-signing-api/assets/95215074/cda74a5b-4f1d-48d7-97ca-2f385a5f4d87">

Lastly, postman collection has been updated to reflect the filing history description format and include filing history description values for testing purposes.

Example:
<img width="792" alt="Screenshot 2023-11-23 at 15 56 13" src="https://github.com/companieshouse/document-signing-api/assets/95215074/c501344a-59d8-4aa2-a75c-f5cd7115df04">




[DCAC-271]: https://companieshouse.atlassian.net/browse/DCAC-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ