### PR TITLE
Added date formatting so dates match CHS style

### DIFF
--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/CoverSheetService.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/CoverSheetService.java
@@ -148,11 +148,11 @@ public class CoverSheetService {
                 coverSheet,
                 contentStream,
                 DEFAULT_MARGIN,
-                590F
+                600F
         );
-        textWrapper(contentStream, DOCUMENT_SIGNED_TEXT, 18, DEFAULT_MARGIN, 550);
+        textWrapper(contentStream, DOCUMENT_SIGNED_TEXT, 18, DEFAULT_MARGIN, 525);
 
-        renderer.renderPageSpacer(contentStream, 530);
+        renderer.renderPageSpacer(contentStream, 515);
         renderer.insertText(contentStream, VIEW_FILE_HEADING, PDType1Font.HELVETICA_BOLD, 18, 480);
 
         contentStream.drawImage(signatureImage, DEFAULT_MARGIN, 420, INFORMATION_SECTION_IMAGE_WIDTH, INFORMATION_SECTION_IMAGE_HEIGHT);

--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGenerator.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGenerator.java
@@ -96,7 +96,7 @@ public class FilingHistoryGenerator {
 
             Map<String, String> formattedDescriptionValues = formatDateValuesInMap(descriptionValues);
             if (formattedDescriptionValues!= null) {
-                filingHistoryDescriptionTail = replaceFilingHistoryDescriptionPlaceholders(filingHistoryDescriptionTail, descriptionValues);
+                filingHistoryDescriptionTail = replaceFilingHistoryDescriptionPlaceholders(filingHistoryDescriptionTail, formattedDescriptionValues);
             }
             filingHistoryDescriptionTail += " (" + coverSheetData.getFilingHistoryType() + ")";
         }
@@ -117,7 +117,7 @@ public class FilingHistoryGenerator {
                 String replacement = entry.getValue();
                 input = input.replace(placeholder, replacement);
             }
-        }
+    }
         return input;
     }
 

--- a/src/test/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGeneratorTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGeneratorTest.java
@@ -30,7 +30,7 @@ public class FilingHistoryGeneratorTest {
     private static final String FILING_HISTORY_DESCRIPTION = "**Registered office address changed** from {old_address} to {new_address} on {change_date}";
 
     private static final Map<String, String> FILING_HISTORY_DESCRIPTION_VALUES = Map.of("old_address", "1 Test Lane",
-            "new_address", "2 Test Lane", "change_date", "01-01-2023");
+            "new_address", "2 Test Lane", "change_date", "2023-01-01");
 
     @InjectMocks
     private FilingHistoryGenerator filingHistoryGenerator;


### PR DESCRIPTION
- Any filing history description values with the key date i.e "change_date", "made_up_date" will be formatted to the CHS style - e.g '2023-01-01' is now 01 Jan 2023
- Plus improved some spacing so longer filing history descriptions have enough space to wrap and remain readable

In fulfilment of DCAC-271.

Latest local run looks like:
![Screenshot 2023-12-04 at 15 48 15 (2)](https://github.com/companieshouse/document-signing-api/assets/95215074/c38f189e-d60e-4c87-a34e-7041cc2829d7)
