### PR TITLE
DCAC-299 - Bugfix for filing history description values

### DIFF
--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/CoverSheetService.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/CoverSheetService.java
@@ -140,16 +140,15 @@ public class CoverSheetService {
 
         textWrapper(contentStream, getCompany(coverSheetData), 18, DEFAULT_MARGIN, 620);
 
-        filingHistoryGenerator.renderFilingHistoryDescriptionWithBoldText(
-                coverSheetData,
-                signPdfData,
-                new Font(PDType1Font.HELVETICA_BOLD, 18),
-                new Font(PDType1Font.HELVETICA, 18),
-                coverSheet,
-                contentStream,
-                DEFAULT_MARGIN,
-                600F
-        );
+        filingHistoryGenerator.applyCorrectFilingHistoryDescriptionTypeFormatting(coverSheetData,
+                                                                                signPdfData,
+                                                                                new Font(PDType1Font.HELVETICA_BOLD, 18),
+                                                                                new Font(PDType1Font.HELVETICA, 18),
+                                                                                coverSheet,
+                                                                                contentStream,
+                                                                                DEFAULT_MARGIN,
+                                                                                600F);
+
         textWrapper(contentStream, DOCUMENT_SIGNED_TEXT, 18, DEFAULT_MARGIN, 490);
 
         renderer.renderPageSpacer(contentStream, 480);

--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGenerator.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGenerator.java
@@ -152,6 +152,16 @@ public class FilingHistoryGenerator {
         return formattedMap;
     }
 
+    /**
+     * Renders a full filing history description for type 1 descriptions on the PDF.
+     * Example of type 1 format: "Notice of **Administrator's proposal**"
+     * @param coverSheetDataDTO Coversheet Data
+     * @param font font for rendering HELVETICA
+     * @param contentStream The content stream for rendering
+     * @param positionX The X-axis starting position on the page
+     * @param positionY The Y-axis starting position on the page
+     * @throws IOException If an I/O error occurs during rendering
+     */
     public void renderFilingHistoryDescriptionType1(final CoverSheetDataDTO coverSheetDataDTO,
                                                     final Font font,
                                                     final PDPageContentStream contentStream,
@@ -180,6 +190,16 @@ public class FilingHistoryGenerator {
         contentStream.endText();
     }
 
+    /**
+     * Renders a full filing history description for type 2 descriptions on the PDF.
+     * Example of type 2 format: "**Statement of Affairs**"
+     * @param coverSheetDataDTO Coversheet Data
+     * @param font font for rendering HELVETICA
+     * @param contentStream The content stream for rendering
+     * @param positionX The X-axis starting position on the page
+     * @param positionY The Y-axis starting position on the page
+     * @throws IOException If an I/O error occurs during rendering
+     */
     public void renderFilingHistoryDescriptionType2(final CoverSheetDataDTO coverSheetDataDTO,
                                                     final Font font,
                                                     final PDPageContentStream contentStream,
@@ -200,7 +220,8 @@ public class FilingHistoryGenerator {
     }
 
     /**
-     * Renders a full filing history description on the PDF, combining the extracted head and populated tail, wrapping the text if necessary.
+     * Renders a full filing history description for type 3 descriptions on the PDF, combining the extracted head and populated tail, wrapping the text if necessary.
+     * Example of type 3 format: "**Statement of Affairs** with form {form_attached}"
      * @param coverSheetDataDTO Coversheet Data
      * @param signPdfRequestDTO Signpdf Request Data
      * @param font1 font1 for rendering HELVETICA_BOLD
@@ -265,6 +286,15 @@ public class FilingHistoryGenerator {
         contentStream.endText();
     };
 
+    /**
+     * Renders a full filing history description for type 4 descriptions on the PDF.
+     * Example of type 4 format: "{original_description}"
+     * @param coverSheetDataDTO Coversheet Data
+     * @param contentStream The content stream for rendering
+     * @param positionX The X-axis starting position on the page
+     * @param positionY The Y-axis starting position on the page
+     * @throws IOException If an I/O error occurs during rendering
+     */
     public void renderFilingHistoryDescriptionType4(final SignPdfRequestDTO signPdfData,
                                                     final CoverSheetDataDTO coverSheetDataDTO,
                                                     final PDPageContentStream contentStream,
@@ -286,6 +316,18 @@ public class FilingHistoryGenerator {
         contentStream.endText();
     }
 
+    /**
+     * Takes a filing history description and identifies the type, then calling the required rendering method for it.
+     * @param coverSheetDataDTO Coversheet Data
+     * @param signPdfRequestDTO Signpdf Request Data
+     * @param font1 font1 for rendering HELVETICA_BOLD
+     * @param font2 font2 for rendering HELVETICA
+     * @param page The PDF page
+     * @param contentStream The content stream for rendering
+     * @param positionX The X-axis starting position on the page
+     * @param positionY The Y-axis starting position on the page
+     * @throws IOException If an I/O error occurs during rendering
+     */
     public void applyCorrectFilingHistoryDescriptionTypeFormatting(final CoverSheetDataDTO coverSheetDataDTO,
                                                                    final SignPdfRequestDTO signPdfRequestDTO,
                                                                    final Font font1,

--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGenerator.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGenerator.java
@@ -152,6 +152,53 @@ public class FilingHistoryGenerator {
         return formattedMap;
     }
 
+    public void renderFilingHistoryDescriptionType1(final CoverSheetDataDTO coverSheetDataDTO,
+                                                    final Font font,
+                                                    final PDPageContentStream contentStream,
+                                                    final Float positionX,
+                                                    final Float positionY)
+                                                    throws IOException {
+
+        String filingHistoryDescription = coverSheetDataDTO.getFilingHistoryDescription();
+        final Position position = new Position(positionX, positionY);
+
+        String regex = "Notice of \\*\\*(.*?)\\*\\*";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(filingHistoryDescription);
+
+        contentStream.beginText();
+        contentStream.newLineAtOffset(position.x, position.y);
+        contentStream.setFont(font.getPdFont(), font.getSize());
+
+        if(matcher.find())
+        {
+            String result = matcher.replaceAll("Notice of $1");
+            contentStream.showText(result + " (" + coverSheetDataDTO.getFilingHistoryType() + ")");
+        }   else {
+            contentStream.showText(filingHistoryDescription);
+        }
+        contentStream.endText();
+    }
+
+    public void renderFilingHistoryDescriptionType2(final CoverSheetDataDTO coverSheetDataDTO,
+                                                    final Font font,
+                                                    final PDPageContentStream contentStream,
+                                                    final Float positionX,
+                                                    final Float positionY)
+                                                    throws IOException {
+
+        String filingHistoryDescription = extractFilingHistoryDescriptionHead(coverSheetDataDTO);
+
+        final Position position = new Position(positionX, positionY);
+
+        contentStream.beginText();
+        contentStream.newLineAtOffset(position.x, position.y);
+
+        contentStream.setFont(font.getPdFont(), font.getSize());
+        contentStream.showText(filingHistoryDescription + " (" + coverSheetDataDTO.getFilingHistoryType() + ")");
+        contentStream.endText();
+    }
+
     /**
      * Renders a full filing history description on the PDF, combining the extracted head and populated tail, wrapping the text if necessary.
      * @param coverSheetDataDTO Coversheet Data
@@ -164,22 +211,20 @@ public class FilingHistoryGenerator {
      * @param positionY The Y-axis starting position on the page
      * @throws IOException If an I/O error occurs during rendering
      */
-    public void renderFilingHistoryDescriptionWithBoldText(
-                                    final CoverSheetDataDTO coverSheetDataDTO,
-                                    final SignPdfRequestDTO signPdfRequestDTO,
-                                    final Font font1,
-                                    final Font font2,
-                                    final PDPage page,
-                                    final PDPageContentStream contentStream,
-                                    final Float positionX,
-                                    final Float positionY)
-                                    throws IOException {
+    public void renderFilingHistoryDescriptionType3(final CoverSheetDataDTO coverSheetDataDTO,
+                                                    final SignPdfRequestDTO signPdfRequestDTO,
+                                                    final Font font1,
+                                                    final Font font2,
+                                                    final PDPage page,
+                                                    final PDPageContentStream contentStream,
+                                                    final Float positionX,
+                                                    final Float positionY)
+                                                    throws IOException {
 
         final String filingHistoryDescriptionHead = extractFilingHistoryDescriptionHead(coverSheetDataDTO);
         final String filingHistoryDescriptionTail = buildFilingHistoryDescriptionTailWithValues(signPdfRequestDTO, coverSheetDataDTO);
 
         final Position position = new Position(positionX, positionY);
-
 
         // Combine head and tail into single text
         String combinedText = filingHistoryDescriptionHead + filingHistoryDescriptionTail;
@@ -220,4 +265,63 @@ public class FilingHistoryGenerator {
         contentStream.endText();
     };
 
+    public void renderFilingHistoryDescriptionType4(final SignPdfRequestDTO signPdfData,
+                                                    final CoverSheetDataDTO coverSheetDataDTO,
+                                                    final PDPageContentStream contentStream,
+                                                    final Float positionX,
+                                                    final Float positionY)
+                                                    throws IOException {
+
+        final Position position = new Position(positionX, positionY);
+
+        String filingHistoryDescription = coverSheetDataDTO.getFilingHistoryDescription();
+        Map<String, String> filingHistoryDescriptionValues = signPdfData.getFilingHistoryDescriptionValues();
+        filingHistoryDescription = replaceFilingHistoryDescriptionPlaceholders(filingHistoryDescription, filingHistoryDescriptionValues);
+        String originalDescription =  filingHistoryDescription + " (" + coverSheetDataDTO.getFilingHistoryType() + ")";
+
+        contentStream.beginText();
+        contentStream.newLineAtOffset(position.x, position.y);
+
+        contentStream.showText(originalDescription);
+        contentStream.endText();
+    }
+
+    public void applyCorrectFilingHistoryDescriptionTypeFormatting(final CoverSheetDataDTO coverSheetDataDTO,
+                                                                   final SignPdfRequestDTO signPdfRequestDTO,
+                                                                   final Font font1,
+                                                                   final Font font2,
+                                                                   final PDPage page,
+                                                                   final PDPageContentStream contentStream,
+                                                                   final Float positionX,
+                                                                   final Float positionY)
+                                                                    throws IOException {
+
+        String filingHistoryDescription = coverSheetDataDTO.getFilingHistoryDescription();
+
+        // Filing History Description Pattern Types Examples
+        // 1. "Notice of **Administrator's proposal**"
+        // 2. "**Statement of Affairs**"
+        // 3. "**Statement of Affairs** with form {form_attached}"
+        // 4. "{original_description}"
+
+        Pattern p1 = Pattern.compile("Notice of .+");
+        Pattern p2 = Pattern.compile("\\*\\*(.*?)\\*\\*$");
+        Pattern p3 = Pattern.compile("\\*\\*(.*?)\\*\\*\\s+(.*?)$");
+        Pattern p4 = Pattern.compile("\\{([^{}]+)\\}");
+
+        Matcher m1 = p1.matcher(filingHistoryDescription);
+        Matcher m2 = p2.matcher(filingHistoryDescription);
+        Matcher m3 = p3.matcher(filingHistoryDescription);
+        Matcher m4 = p4.matcher(filingHistoryDescription);
+
+        if (m1.find()) {
+            renderFilingHistoryDescriptionType1(coverSheetDataDTO, font2,contentStream, positionX, positionY );
+        } else if (m2.find()){
+            renderFilingHistoryDescriptionType2(coverSheetDataDTO, font2, contentStream, positionX, positionY);
+        } else if (m3.find()){
+            renderFilingHistoryDescriptionType3(coverSheetDataDTO, signPdfRequestDTO, font1, font2, page, contentStream, positionX, positionY);
+        } else if (m4.find()){
+            renderFilingHistoryDescriptionType4(signPdfRequestDTO, coverSheetDataDTO, contentStream, positionX, positionY);
+        }
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGenerator.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGenerator.java
@@ -210,10 +210,6 @@ public class FilingHistoryGenerator {
         String filingHistoryDescription = extractFilingHistoryDescriptionHead(coverSheetDataDTO);
 
         final Position position = new Position(positionX, positionY);
-
-        if(coverSheetDataDTO.getFilingHistoryType() != null) {
-            filingHistoryDescription += " (" + coverSheetDataDTO.getFilingHistoryType() + ")";
-        }
         
         contentStream.beginText();
         contentStream.newLineAtOffset(position.x, position.y);

--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGenerator.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGenerator.java
@@ -211,8 +211,10 @@ public class FilingHistoryGenerator {
 
         final Position position = new Position(positionX, positionY);
 
-        filingHistoryDescription += " (" + coverSheetDataDTO.getFilingHistoryType() + ")";
-
+        if(coverSheetDataDTO.getFilingHistoryType() != null) {
+            filingHistoryDescription += " (" + coverSheetDataDTO.getFilingHistoryType() + ")";
+        }
+        
         contentStream.beginText();
         contentStream.newLineAtOffset(position.x, position.y);
 

--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGenerator.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGenerator.java
@@ -211,11 +211,14 @@ public class FilingHistoryGenerator {
 
         final Position position = new Position(positionX, positionY);
 
+        filingHistoryDescription += " (" + coverSheetDataDTO.getFilingHistoryType() + ")";
+
         contentStream.beginText();
         contentStream.newLineAtOffset(position.x, position.y);
 
         contentStream.setFont(font.getPdFont(), font.getSize());
-        contentStream.showText(filingHistoryDescription + " (" + coverSheetDataDTO.getFilingHistoryType() + ")");
+
+        contentStream.showText(filingHistoryDescription);
         contentStream.endText();
     }
 

--- a/src/test/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGeneratorTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGeneratorTest.java
@@ -4,6 +4,7 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.PDPageTree;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationLink;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,10 +28,17 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 public class FilingHistoryGeneratorTest {
 
-    private static final String FILING_HISTORY_DESCRIPTION = "**Registered office address changed** from {old_address} to {new_address} on {change_date}";
+    private static final String FILING_HISTORY_DESCRIPTION_TYPE_1 = "Notice of **Administrator's proposal**";
 
-    private static final Map<String, String> FILING_HISTORY_DESCRIPTION_VALUES = Map.of("old_address", "1 Test Lane",
+    private static final String FILING_HISTORY_DESCRIPTION_TYPE_2 = "**Statement of Affairs**";
+
+    private static final String FILING_HISTORY_DESCRIPTION_TYPE_3 = "**Registered office address changed** from {old_address} to {new_address} on {change_date}";
+
+    private static final String FILING_HISTORY_DESCRIPTION_TYPE_4 = "{original_description}";
+    private static final Map<String, String> FILING_HISTORY_DESCRIPTION_TYPE_3_VALUES = Map.of("old_address", "1 Test Lane",
             "new_address", "2 Test Lane", "change_date", "2023-01-01");
+
+    private static final Map<String, String> FILING_HISTORY_DESCRIPTION_TYPE_4_VALUES = Map.of("original_description", "Test original description");
 
     @InjectMocks
     private FilingHistoryGenerator filingHistoryGenerator;
@@ -58,19 +66,58 @@ public class FilingHistoryGeneratorTest {
         filingHistoryGenerator = new FilingHistoryGenerator();
     }
 
-
     @Test
-    @DisplayName("filing history generator renders text a total of 3 times")
-    void rendersText() throws IOException {
+    @DisplayName("filing history generator renders filing history descriptions of type 1 text a total of 1 times")
+    void rendersFilingHistoryDescriptionType1Text() throws IOException {
         executeTest((pdfBox, pageConstructor, streamConstructor, linkConstructor) -> {
 
             CoverSheetDataDTO coverSheetData = new CoverSheetDataDTO();
-            coverSheetData.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION);
+            coverSheetData.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION_TYPE_1);
+
+            filingHistoryGenerator.renderFilingHistoryDescriptionType1(
+                                                        coverSheetData,
+                                                        new Font(PDType1Font.HELVETICA, 18),
+                                                        contentStream,
+                                                        25F,
+                                                        590F);
+
+            verify(contentStream, times(1)).showText(any(String.class));
+
+        });
+    }
+
+    @Test
+    @DisplayName("filing history generator renders filing history descriptions of type 2 text a total of 1 times")
+    void rendersFilingHistoryDescriptionType2Text() throws IOException {
+        executeTest((pdfBox, pageConstructor, streamConstructor, linkConstructor) -> {
+
+            CoverSheetDataDTO coverSheetData = new CoverSheetDataDTO();
+            coverSheetData.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION_TYPE_2);
+
+            filingHistoryGenerator.renderFilingHistoryDescriptionType2(
+                                                        coverSheetData,
+                                                        new Font(PDType1Font.HELVETICA, 18),
+                                                        contentStream,
+                                                        25F,
+                                                        590F);
+
+            verify(contentStream, times(1)).showText(any(String.class));
+
+        });
+    }
+
+    @Test
+    @DisplayName("filing history generator renders filing history descriptions of type 3 text a total of 3 times")
+    void rendersFilingHistoryDescriptionType3Text() throws IOException {
+        executeTest((pdfBox, pageConstructor, streamConstructor, linkConstructor) -> {
+
+            CoverSheetDataDTO coverSheetData = new CoverSheetDataDTO();
+            coverSheetData.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION_TYPE_3);
 
             SignPdfRequestDTO signPdfRequestDTO = new SignPdfRequestDTO();
-            signPdfRequestDTO.setFilingHistoryDescriptionValues(FILING_HISTORY_DESCRIPTION_VALUES);
+            signPdfRequestDTO.setFilingHistoryDescriptionValues(FILING_HISTORY_DESCRIPTION_TYPE_3_VALUES);
 
-            filingHistoryGenerator.renderFilingHistoryDescriptionWithBoldText(
+            filingHistoryGenerator.renderFilingHistoryDescriptionType3(
                                                         coverSheetData,
                                                         signPdfRequestDTO,
                                                         font,
@@ -81,6 +128,28 @@ public class FilingHistoryGeneratorTest {
                                                         590F);
 
             verify(contentStream, times(3)).showText(any(String.class));
+        });
+    }
+
+    @Test
+    @DisplayName("filing history generator renders filing history descriptions of type 4 text a total of 1 times")
+    void rendersFilingHistoryDescriptionType4Text() throws IOException {
+        executeTest((pdfBox, pageConstructor, streamConstructor, linkConstructor) -> {
+
+            CoverSheetDataDTO coverSheetData = new CoverSheetDataDTO();
+            coverSheetData.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION_TYPE_4);
+
+            SignPdfRequestDTO signPdfRequestDTO = new SignPdfRequestDTO();
+            signPdfRequestDTO.setFilingHistoryDescriptionValues(FILING_HISTORY_DESCRIPTION_TYPE_4_VALUES);
+
+            filingHistoryGenerator.renderFilingHistoryDescriptionType4(
+                                                        signPdfRequestDTO,
+                                                        coverSheetData,
+                                                        contentStream,
+                                                        25F,
+                                                        590F);
+
+            verify(contentStream, times(1)).showText(any(String.class));
         });
     }
 


### PR DESCRIPTION
Fulfils bug ticket [DCAC-299](https://companieshouse.atlassian.net/browse/DCAC-299)

Categorised the filing history descriptions into four types, an example of each:
1. "Notice of **Administrator's proposal**"
2. "**Statement of Affairs**"
3. "**Statement of Affairs** with form {form_attached}"
4. "{original_description}"

Original ticket DCAC-271 only accounted for type 3, so the filing history generator has been expanded to identify and then apply a rendering method for each. Screenshots of how each now looks on the PDF provided below:

1. "Notice of **Administrator's proposal**"

<img width="791" alt="Screenshot 2024-01-15 at 16 51 58" src="https://github.com/companieshouse/document-signing-api/assets/95215074/6c916492-c92d-43b8-b82b-aef855d33117">

2. "**Statement of Affairs**"

<img width="791" alt="Screenshot 2024-01-15 at 16 53 17" src="https://github.com/companieshouse/document-signing-api/assets/95215074/65dc35c1-ec0c-4c77-b9d1-8afdd108bba4">

3. "**Statement of Affairs** with form {form_attached}"

<img width="786" alt="Screenshot 2024-01-15 at 16 55 04" src="https://github.com/companieshouse/document-signing-api/assets/95215074/67bb209a-9534-4da4-8f0a-02cac8c44e11">

4. "{original_description}"

<img width="788" alt="Screenshot 2024-01-15 at 16 56 36" src="https://github.com/companieshouse/document-signing-api/assets/95215074/66e1a43b-2c95-44d4-8477-ad1e6141ebe9">



[DCAC-299]: https://companieshouse.atlassian.net/browse/DCAC-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ