### PR TITLE
dcac-299/adding-fifth-type-of-filing-history-description

### DIFF
--- a/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGenerator.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGenerator.java
@@ -210,7 +210,7 @@ public class FilingHistoryGenerator {
         String filingHistoryDescription = extractFilingHistoryDescriptionHead(coverSheetDataDTO);
 
         final Position position = new Position(positionX, positionY);
-        
+
         contentStream.beginText();
         contentStream.newLineAtOffset(position.x, position.y);
 
@@ -318,6 +318,34 @@ public class FilingHistoryGenerator {
     }
 
     /**
+     * Renders a full filing history description for type 5 descriptions on the PDF.
+     * This is a catch all designed to capture any formats not yet covered, and display the text on the PDF.
+     * @param coverSheetDataDTO Coversheet Data
+     * @param contentStream The content stream for rendering
+     * @param positionX The X-axis starting position on the page
+     * @param positionY The Y-axis starting position on the page
+     * @throws IOException If an I/O error occurs during rendering
+     */
+    public void renderFilingHistoryDescriptionType5(final SignPdfRequestDTO signPdfData,
+                                                    final CoverSheetDataDTO coverSheetDataDTO,
+                                                    final PDPageContentStream contentStream,
+                                                    final Float positionX,
+                                                    final Float positionY)
+                                                    throws IOException {
+
+        final Position position = new Position(positionX, positionY);
+
+        String filingHistoryDescription = coverSheetDataDTO.getFilingHistoryDescription();
+        String filingHistoryDescriptionPlusType = filingHistoryDescription + " (" + coverSheetDataDTO.getFilingHistoryType() + ")";
+
+        contentStream.beginText();
+        contentStream.newLineAtOffset(position.x, position.y);
+
+        contentStream.showText(filingHistoryDescriptionPlusType);
+        contentStream.endText();
+    }
+
+    /**
      * Takes a filing history description and identifies the type, then calling the required rendering method for it.
      * @param coverSheetDataDTO Coversheet Data
      * @param signPdfRequestDTO Signpdf Request Data
@@ -343,9 +371,10 @@ public class FilingHistoryGenerator {
 
         // Filing History Description Pattern Types Examples
         // 1. "Notice of **Administrator's proposal**"
-        // 2. "**Statement of Affairs**"
+        // 2. "**Statement of Affairs**" or
         // 3. "**Statement of Affairs** with form {form_attached}"
         // 4. "{original_description}"
+        // 5. "Certificates that Creditors have been paid in full" or any other format
 
         Pattern p1 = Pattern.compile("Notice of .+");
         Pattern p2 = Pattern.compile("\\*\\*(.*?)\\*\\*$");
@@ -365,6 +394,8 @@ public class FilingHistoryGenerator {
             renderFilingHistoryDescriptionType3(coverSheetDataDTO, signPdfRequestDTO, font1, font2, page, contentStream, positionX, positionY);
         } else if (m4.find()){
             renderFilingHistoryDescriptionType4(signPdfRequestDTO, coverSheetDataDTO, contentStream, positionX, positionY);
+        } else {
+            renderFilingHistoryDescriptionType5(signPdfRequestDTO, coverSheetDataDTO, contentStream, positionX, positionY);
         }
     }
 }

--- a/src/test/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGeneratorTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningapi/coversheet/FilingHistoryGeneratorTest.java
@@ -35,6 +35,8 @@ public class FilingHistoryGeneratorTest {
     private static final String FILING_HISTORY_DESCRIPTION_TYPE_3 = "**Registered office address changed** from {old_address} to {new_address} on {change_date}";
 
     private static final String FILING_HISTORY_DESCRIPTION_TYPE_4 = "{original_description}";
+
+    private static final String FILING_HISTORY_DESCRIPTION_TYPE_5 = "Certificate that Creditors have been paid in full";
     private static final Map<String, String> FILING_HISTORY_DESCRIPTION_TYPE_3_VALUES = Map.of("old_address", "1 Test Lane",
             "new_address", "2 Test Lane", "change_date", "2023-01-01");
 
@@ -148,6 +150,26 @@ public class FilingHistoryGeneratorTest {
                                                         contentStream,
                                                         25F,
                                                         590F);
+
+            verify(contentStream, times(1)).showText(any(String.class));
+        });
+    }
+
+    @Test
+    @DisplayName("filing history generator renders filing history descriptions of type 5 just once")
+    void rendersFilingHistoryDescriptionType5Text() throws IOException {
+        executeTest((pdfBox, pageConstructor, streamConstructor, linkConstructor) -> {
+
+            CoverSheetDataDTO coverSheetData = new CoverSheetDataDTO();
+            coverSheetData.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION_TYPE_5);
+            SignPdfRequestDTO signPdfRequestDTO = new SignPdfRequestDTO();
+
+            filingHistoryGenerator.renderFilingHistoryDescriptionType4(
+                    signPdfRequestDTO,
+                    coverSheetData,
+                    contentStream,
+                    25F,
+                    590F);
 
             verify(contentStream, times(1)).showText(any(String.class));
         });


### PR DESCRIPTION
Fulfils [DCAC-299](https://companieshouse.atlassian.net/browse/DCAC-299)

Fifth type of possible enumeration found during testing, format is simply a plain String, example:

"Certificate that Creditors have been paid in full"

Added a 5th rendering method to handle this, plus catch any other unknown types to ensure they get displayed on the PDF.

Extra test also added.

[DCAC-299]: https://companieshouse.atlassian.net/browse/DCAC-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Screenshot of local test result below:

![Screenshot 2024-01-18 at 14 14 04 (2)](https://github.com/companieshouse/document-signing-api/assets/95215074/efb2ee79-6446-4b53-8036-f24ccbf9a70b)
