### PR TITLE
Set dependency-check up according to current standards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,12 @@
 artifact_name       := document-signing-api
 version             := "unversioned"
-dependency_check_base_suppressions:=common_suppressions_spring_6.xml
-# dependency_check_suppressions_repo_branch
-# The branch of the dependency-check-suppressions repository to use
-# as the source of the suppressions file.
-# This should point to "main" branch when being used for release,
-# but can point to a different branch for experimentation/development.
-dependency_check_suppressions_repo_branch:=feature/suppressions-for-company-accounts-api
 
+dependency_check_base_suppressions:=common_suppressions_spring_6.xml
+dependency_check_suppressions_repo_branch:=main
 dependency_check_minimum_cvss := 4
 dependency_check_assembly_analyzer_enabled := false
 dependency_check_suppressions_repo_url:=git@github.com:companieshouse/dependency-check-suppressions.git
 suppressions_file := target/suppressions.xml
-##### End of variable block
 
 .PHONY: all
 all: build
@@ -88,7 +82,7 @@ dependency-check:
 	suppressions_path="$${suppressions_home}/suppressions/$(dependency_check_base_suppressions)"; \
 	if [  -f "$${suppressions_path}" ]; then \
 		cp -av "$${suppressions_path}" $(suppressions_file); \
-		mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
+		mvn org.owasp:dependency-check-maven:check -Dformats="json,html" -DprettyPrint -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
 	else \
 		printf -- "\n ERROR Cannot find suppressions file at '%s'\n" "$${suppressions_path}" >&2; \
 		exit 1; \
@@ -96,3 +90,4 @@ dependency-check:
 
 .PHONY: security-check
 security-check: dependency-check
+


### PR DESCRIPTION
Tidy, repoint at dep-check-suppressions/main
The 'dependency-check' target uses a variable dependency_check_suppressions_repo_branch which previously pointed to a different branch: feature/suppressions-for-company-accounts-api ... but that branch has been merged into main and so this variable should now point to main.

Tidied Makefile for dependency-check consistency.
Made line spacing, ordering, format for dependency-check sections
identical across Makefiles.
Added json to dependency check report formats.

See [CC-1745](https://companieshouse.atlassian.net/browse/CC-1745)

[CC-1745]: https://companieshouse.atlassian.net/browse/CC-1745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ