### PR TITLE
read only root file system set to false

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -21,6 +21,7 @@ terraform {
 
 module "ecs-service" {
   source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.294"
+  read_only_root_filesystem = false
 
   # Environmental configuration
   environment             = var.environment


### PR DESCRIPTION
undo read only root file system, logs show 

./docker_start.sh: line 23: keystore.p12: Read-only file system
Failed to decode the keystore

something to look into possibly.